### PR TITLE
トゥーンシェーディングの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.a
 a.out
 miniRT
-tutorial/tutorial

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ SRCS :=	srcs/main.c \
 		srcs/intersection_test.c \
 		srcs/intersection_test_utils.c \
 		srcs/raytrace.c \
-		srcs/init.c
+		srcs/init.c \
+		srcs/toon.c
 OBJS := $(SRCS:.c=.o)
 
 MLXDIR := ./minilibx-linux

--- a/srcs/color.c
+++ b/srcs/color.c
@@ -23,7 +23,8 @@ void	add_color(const t_material *mat, t_refdata *refdata, t_color *out_col)
 	normalize(&ref_vec);
 	reverseray_vec = times(-1, refdata->ray);
 	normalize(&reverseray_vec);
-	pow_val = pow(dot(&ref_vec, &reverseray_vec), mat->shininess);
+	pow_val = pow(calc_toon(dot(&ref_vec, &reverseray_vec), \
+		refdata->use_toon), mat->shininess);
 	specular_ref_light = cmult(mat->specular_ref, \
 							ctimes(pow_val, refdata->light));
 	*out_col = cadd(*out_col, cadd(diffuse_ref_light, specular_ref_light));

--- a/srcs/miniRT.h
+++ b/srcs/miniRT.h
@@ -23,6 +23,8 @@
 # ifndef M_PI
 #  define M_PI 3.141592653589793
 # endif
+# define TOON_LEVEL 4.0
+# define TOON_EDGE_THICKNESS 0.25
 
 typedef enum e_formula
 {
@@ -101,6 +103,7 @@ typedef struct s_camera {
 typedef struct s_light
 {
 	double	ratio;
+	bool	use_toon;
 	t_vec3	pos;
 	t_color	c;
 }	t_light;
@@ -147,6 +150,7 @@ typedef struct s_refdata {
 	t_vec3	incidence;
 	t_color	light;
 	double	norm_dot_inc;
+	bool	use_toon;
 }	t_refdata;
 
 typedef struct s_world {
@@ -240,5 +244,9 @@ bool	print_error(const int line_count, const t_error_status error_status);
 
 void	data_init(t_data *data);
 //init
+
+bool	toon_edge(t_vec3 norm, t_vec3 dir, t_color *out_col, bool use_toon);
+double	calc_toon(double dot, bool use_toon);
+// toon
 
 #endif

--- a/srcs/miniRT.h
+++ b/srcs/miniRT.h
@@ -24,7 +24,7 @@
 #  define M_PI 3.141592653589793
 # endif
 # define TOON_LEVEL 4.0
-# define TOON_EDGE_THICKNESS 0.25
+# define TOON_EDGE_THICKNESS 0.20
 
 typedef enum e_formula
 {

--- a/srcs/miniRT.h
+++ b/srcs/miniRT.h
@@ -245,6 +245,7 @@ bool	print_error(const int line_count, const t_error_status error_status);
 void	data_init(t_data *data);
 //init
 
+bool	atotoon(char *s, bool *use_toon);
 bool	toon_edge(t_vec3 norm, t_vec3 dir, t_color *out_col, bool use_toon);
 double	calc_toon(double dot, bool use_toon);
 // toon

--- a/srcs/parser_env_elems.c
+++ b/srcs/parser_env_elems.c
@@ -44,11 +44,8 @@ bool	parser_light(t_world *w, char **info)
 		return (false);
 	if (!atocol(info[3], &w->light.c))
 		return (false);
-	w->env_elems_exists[2] = true;
-	w->light.use_toon = false;
-	if (ft_strequal(info[4], "TOON", 5))
-		w->light.use_toon = true;
-	else if (info[4])
+	if (!atotoon(info[4], &w->light.use_toon))
 		return (false);
+	w->env_elems_exists[2] = true;
 	return (true);
 }

--- a/srcs/parser_env_elems.c
+++ b/srcs/parser_env_elems.c
@@ -32,7 +32,10 @@ bool	parser_camera(t_world *w, char **info)
 
 bool	parser_light(t_world *w, char **info)
 {
-	if (ft_str_arr_len(info) != 4)
+	int	str_arr_len;
+
+	str_arr_len = ft_str_arr_len(info);
+	if (str_arr_len != 4 && str_arr_len != 5)
 		return (false);
 	if (!atovec3(info[1], &w->light.pos))
 		return (false);
@@ -42,5 +45,10 @@ bool	parser_light(t_world *w, char **info)
 	if (!atocol(info[3], &w->light.c))
 		return (false);
 	w->env_elems_exists[2] = true;
+	w->light.use_toon = false;
+	if (ft_strequal(info[4], "TOON", 5))
+		w->light.use_toon = true;
+	else if (info[4])
+		return (false);
 	return (true);
 }

--- a/srcs/raytrace.c
+++ b/srcs/raytrace.c
@@ -66,7 +66,8 @@ bool	reflection_test(const t_world *w, const t_ray *cam_ray, \
 	refdata->normal = intp->normal;
 	refdata->incidence = sub(w->light.pos, intp->pos);
 	normalize(&refdata->incidence);
-	refdata->norm_dot_inc = dot(&refdata->normal, &refdata->incidence);
+	refdata->use_toon = w->light.use_toon;
+	refdata->norm_dot_inc = calc_toon(dot(&refdata->normal, &refdata->incidence), refdata->use_toon);
 	if (refdata->norm_dot_inc <= 0)
 		return (false);
 	refdata->light = ctimes(w->light.ratio, w->light.c);
@@ -82,6 +83,8 @@ bool	raytrace(const t_world *w, const t_ray *cam_ray, t_color *out_col)
 
 	if (!get_nearest_obj(w, cam_ray, &nearest_obj, &nearest_intp))
 		return (false);
+	if (toon_edge(nearest_intp.normal, cam_ray->direction, out_col, w->light.use_toon))
+		return (true);
 	get_material(nearest_obj, &mat);
 	*out_col = cmult(mat.ambient_ref, \
 				ctimes(w->amb_light.ratio, w->amb_light.c));

--- a/srcs/toon.c
+++ b/srcs/toon.c
@@ -1,0 +1,20 @@
+#include "miniRT.h"
+
+double	calc_toon(double dot, bool use_toon)
+{
+	if (!use_toon)
+		return (dot);
+	return (ceil(TOON_LEVEL * (1 - (2 / M_PI) * acos(dot))) / TOON_LEVEL);
+}
+
+bool	toon_edge(t_vec3 norm, t_vec3 dir, t_color *out_col, bool use_toon)
+{
+	if (!use_toon)
+		return (false);
+	normalize(&norm);
+	normalize(&dir);
+	if (fabs(dot(&norm, &dir)) > TOON_EDGE_THICKNESS)
+		return (false);
+	*out_col = color(0, 0, 0);
+	return (true);
+}

--- a/srcs/toon.c
+++ b/srcs/toon.c
@@ -11,7 +11,6 @@ bool	toon_edge(t_vec3 norm, t_vec3 dir, t_color *out_col, bool use_toon)
 {
 	if (!use_toon)
 		return (false);
-	normalize(&norm);
 	normalize(&dir);
 	if (fabs(dot(&norm, &dir)) > TOON_EDGE_THICKNESS)
 		return (false);

--- a/srcs/toon.c
+++ b/srcs/toon.c
@@ -18,3 +18,16 @@ bool	toon_edge(t_vec3 norm, t_vec3 dir, t_color *out_col, bool use_toon)
 	*out_col = color(0, 0, 0);
 	return (true);
 }
+
+bool	atotoon(char *s, bool *use_toon)
+{
+	*use_toon = false;
+	if (!s)
+		return (true);
+	if (ft_strequal(s, "TOON", 5))
+	{
+		*use_toon = true;
+		return (true);
+	}
+	return (false);
+}

--- a/srcs/vector_utils3.c
+++ b/srcs/vector_utils3.c
@@ -20,6 +20,11 @@ double	normalize(t_vec3 *v)
 	double	vnorm;
 
 	vnorm = norm(v);
+	if (vnorm == 0)
+	{
+		*v = vec3(0, 0, 0);
+		return (0);
+	}
 	v->x /= vnorm;
 	v->y /= vnorm;
 	v->z /= vnorm;


### PR DESCRIPTION
https://knzw.tech/raytracing/?page_id=1621#toc-03476ddd7e79e9c8fa7d759966a93ba4-7
説明に関しては正直これ見るのが一番早いです、そんなに長くないし
放射輝度の離散化と輪郭をつける

みる方法としては
```diff
-L -5,1,6 0.7 255,255,255
+L -5,1,6 0.7 255,255,255 TOON
```

issueのlight_close_pl_mosaic だけちょっと変な見た目になりますが、離散化するとこうなることもあるのか～～くらいの認識です

